### PR TITLE
Support alternate mapping instantiation

### DIFF
--- a/csv_utils/transforms.py
+++ b/csv_utils/transforms.py
@@ -304,15 +304,19 @@ class RenameValue(Transform):
     """
     Renames a value or values in a given column of a DataFrame.
 
+    .. note::
+        Passing ``mapping`` as a list of tuples is supported to enable jsonargparse instantiation when
+        keys contain spaces. However, the mapping is converted to a dictionary internally.
+
     Args:
         column: The column on which to perform the value renaming.
-        mapping: A dictionary containing the old value(s) as keys and the new value(s) as values.
+        mapping: Defines the mapping of old to new values. Can be a dictionary mapping or a list of mapping tuples.
         as_string: If True, compare values as strings.
         output_column: The name of the column to store the result. If None, the original column is updated in place.
     """
 
     column: str
-    mapping: Dict[Any, Any]
+    mapping: Dict[Any, Any] | List[Tuple[Any, Any]]
     default: Any | None = None
     as_string: bool = False
     output_column: str | None = None
@@ -320,6 +324,7 @@ class RenameValue(Transform):
     def __post_init__(self):
         if not self.mapping:
             raise ValueError("mapping cannot be empty")
+        self.mapping = dict(self.mapping) if isinstance(self.mapping, list) else self.mapping
 
     def __call__(self, table: pd.DataFrame) -> pd.DataFrame:
         # Validate inputs
@@ -327,6 +332,7 @@ class RenameValue(Transform):
             raise KeyError(f"column {self.column} not in table.columns {table.columns}")
 
         mapping = self.mapping
+        assert isinstance(mapping, dict)
         if self.as_string:
             mapping = {str(k): v for k, v in mapping.items()}
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -234,6 +234,7 @@ def test_rename_column(df_factory, old_name, new_name, copy, exp):
         assert list(result.columns) == exp
 
 
+@pytest.mark.parametrize("as_dict", [True, False])
 @pytest.mark.parametrize(
     "as_string,col,old_value,new_value,exp",
     [
@@ -253,9 +254,9 @@ def test_rename_column(df_factory, old_name, new_name, copy, exp):
         pytest.param(True, "col2", 1, "one", ["one", 4, 7, 10, 13, 16, 19, 22, 25, 28]),
     ],
 )
-def test_rename_value(df_factory, as_string, col, old_value, new_value, exp):
+def test_rename_value(df_factory, as_string, col, old_value, new_value, as_dict, exp):
     df = df_factory()
-    mapping = {old_value: new_value}
+    mapping = {old_value: new_value} if as_dict else [(old_value, new_value)]
     result = RenameValue(col, mapping, as_string=as_string)(df)
     assert list(result[col]) == exp
 


### PR DESCRIPTION
It seems jsonargparse will not instantiate keys that contain a space, which prevents the instantiation of some dicts. This PR supports a list of key value tuples as an alternative mapping type to avoid the instantiation problem.